### PR TITLE
Third party cookbook hard-coupling

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -61,7 +61,6 @@ suites:
   - name: default
     run_list:
       - recipe[auditd]
-      - recipe[sysctl::apply]
       - recipe[stig]
       - recipe[stig::auditd]
       - recipe[stig::auditd_rules]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelog
 ---------
 
+- 0.5.1
+-- [isuftin@usgs.gov] - Included third-party sysctl cookbook as a hard-coupled dependency by calling it in proc_hard recipe
+
 - 0.5.0
 -- [isuftin@usgs.gov] - Switched sysctl.conf template writing out and brought in the third-party sysctl cookbook to handle writing .d config file
 -- [isuftin@usgs.gov] - Updated serverspec testing

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'isuftin@usgs.gov'
 license          'Public domain'
 description      'Installs/Configures CIS STIG benchmarks'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.5.0'
+version          '0.5.1'
 source_url		 'https://github.com/USGS-CIDA/stig'
 issues_url		 'https://github.com/USGS-CIDA/stig/issues'
 

--- a/recipes/proc_hard.rb
+++ b/recipes/proc_hard.rb
@@ -44,6 +44,8 @@ package "whoopsie" do
   only_if { %w{debian ubuntu}.include? platform }
 end
 
+include_recipe "sysctl::apply"
+
 ip_forwarding = node["stig"]["network"]["ip_forwarding"]
 
 send_redirects = node["stig"]["network"]["packet_redirects"]

--- a/test/integration/default/serverspec/proc_hard_spec.rb
+++ b/test/integration/default/serverspec/proc_hard_spec.rb
@@ -24,6 +24,12 @@ if ['debian','ubuntu'].include?(host_inventory['platform'])
   end
 end
 
+# CENTOS 5.1.1
+# UBUNTU 7.1.1
+describe command('/sbin/sysctl net.ipv4.ip_forward') do
+  its(:stdout) { should match /net.ipv4.ip_forward = 0/ }
+end
+
 describe command('sysctl fs.suid_dumpable') do
   its(:stdout) { should match /fs.suid_dumpable = 0/ }
 end


### PR DESCRIPTION
-- [isuftin@usgs.gov] - Included third-party sysctl cookbook as a hard-coupled dependency by calling it in proc_hard recipe