### PR TITLE
sysctl updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 ---------
 
+- 0.6.5
+
+-- [isuftin@usgs.gov] - Leaving sysctl attribute mutation solely to the sysctl cookbook.
+-- [isuftin@usgs.gov] - Removing STIG cookbook attributes for sysctl. Using only
+sysctl cookbook attributes
+
 - 0.6.4
 
 -- [isuftin@usgs.gov] - Update mail transfer agent recipe to fully parameterize the CentOS template for main.cf

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -111,64 +111,54 @@ default['stig']['network']['zeroconf'] = true
 # Disable IP Forwarding
 # false = IP forwarding disabled
 # true = IP forwarding enabled
-default['stig']['network']['ip_forwarding'] = 0
-default['sysctl']['params']['net.ipv4.ip_forward'] = node['stig']['network']['ip_forwarding']
+default['sysctl']['params']['net.ipv4.ip_forward'] = 0
 
 # Disable Send Packet Redirects
 # false = Disable redirects
 # true = Enable redirects
-default['stig']['network']['packet_redirects'] = 0
-default['sysctl']['params']['net.ipv4.conf.all.send_redirects'] = node['stig']['network']['packet_redirects']
-default['sysctl']['params']['net.ipv4.conf.default.send_redirects'] = node['stig']['network']['packet_redirects']
+default['sysctl']['params']['net.ipv4.conf.all.send_redirects'] = 0
+default['sysctl']['params']['net.ipv4.conf.default.send_redirects'] = 0
 
 # Disable ICMP Redirect Acceptance
 # false = Disable redirect acceptance
 # true = Enable redirect acceptance
-default['stig']['network']['icmp_redirect_accept'] = 0
-default['sysctl']['params']['net.ipv4.conf.all.accept_redirects'] = node['stig']['network']['icmp_redirect_accept']
-default['sysctl']['params']['net.ipv4.conf.default.accept_redirects'] = node['stig']['network']['icmp_redirect_accept']
+default['sysctl']['params']['net.ipv4.conf.all.accept_redirects'] = 0
+default['sysctl']['params']['net.ipv4.conf.default.accept_redirects'] = 0
 
 # Log Suspicious Packets
 # true / false
-default['stig']['network']['log_suspicious_packets'] = 1
-default['sysctl']['params']['net.ipv4.conf.all.log_martians'] = node['stig']['network']['log_suspicious_packets']
-default['sysctl']['params']['net.ipv4.conf.default.log_martians'] = node['stig']['network']['log_suspicious_packets']
+default['sysctl']['params']['net.ipv4.conf.all.log_martians'] = 1
+default['sysctl']['params']['net.ipv4.conf.default.log_martians'] = 1
 
 # Enable RFC-recommended Source Route Validation
 # true / false
-default['stig']['network']['rfc_source_route_validation'] = 1
-default['sysctl']['params']['net.ipv4.conf.all.rp_filter'] = node['stig']['network']['rfc_source_route_validation']
-default['sysctl']['params']['net.ipv4.conf.default.rp_filter'] = node['stig']['network']['rfc_source_route_validation']
+default['sysctl']['params']['net.ipv4.conf.all.rp_filter'] = 1
+default['sysctl']['params']['net.ipv4.conf.default.rp_filter'] = 1
 
 # Disable IPv6 Redirect Acceptance
 # false = Disable redirect acceptance
 # true = Enable redirect acceptance
-default['stig']['network']['ipv6_redirect_accept'] = 0
-default['sysctl']['params']['net.ipv6.conf.all.accept_redirects'] = node['stig']['network']['ipv6_redirect_accept']
-default['sysctl']['params']['net.ipv6.conf.default.accept_redirects'] = node['stig']['network']['ipv6_redirect_accept']
+default['sysctl']['params']['net.ipv6.conf.all.accept_redirects'] = 0
+default['sysctl']['params']['net.ipv6.conf.default.accept_redirects'] = 0
 
 # Disable Secure ICMP Redirect Acceptance
 # false = Disable redirect acceptance
 # true = Enable redirect acceptance
-default['stig']['network']['icmp_all_secure_redirect_accept'] = 0
-default['sysctl']['params']['net.ipv4.conf.all.secure_redirects'] = node['stig']['network']['icmp_all_secure_redirect_accept']
-default['sysctl']['params']['net.ipv4.conf.default.secure_redirects'] = node['stig']['network']['icmp_all_secure_redirect_accept']
+default['sysctl']['params']['net.ipv4.conf.all.secure_redirects'] = 0
+default['sysctl']['params']['net.ipv4.conf.default.secure_redirects'] = 0
 
 # Disable IPv6 Router Advertisements
 # false = Disable IPv6 router advertisements
 # true = Enable IPv6 router advertisements
-default['stig']['network']['ipv6_ra_accept'] = 0
-default['sysctl']['params']['net.ipv6.conf.all.accept_ra'] = node['stig']['network']['ipv6_ra_accept']
-default['sysctl']['params']['net.ipv6.conf.default.accept_ra'] = node['stig']['network']['ipv6_ra_accept']
-default['sysctl']['params']['net.ipv6.conf.default.accept_ra'] = node['stig']['network']['ipv6_ra_accept']
+default['sysctl']['params']['net.ipv6.conf.all.accept_ra'] = 0
+default['sysctl']['params']['net.ipv6.conf.default.accept_ra'] = 0
 
 # Disable IPv6
 # false = Do not disable ipv6
 # true = Disable ipv6
-default['stig']['network']['ipv6_disable'] = 1
-default['sysctl']['params']['net.ipv6.conf.all.disable_ipv6'] = node['stig']['network']['ipv6_disable']
-default['sysctl']['params']['net.ipv6.conf.default.disable_ipv6'] = node['stig']['network']['ipv6_disable']
-default['sysctl']['params']['net.ipv6.conf.lo.disable_ipv6'] = node['stig']['network']['ipv6_disable']
+default['sysctl']['params']['net.ipv6.conf.all.disable_ipv6'] = 1
+default['sysctl']['params']['net.ipv6.conf.default.disable_ipv6'] = 1
+default['sysctl']['params']['net.ipv6.conf.lo.disable_ipv6'] = 1
 
 # Create /etc/hosts.allow
 # An array of <net>/<mask> combinations or ['ALL']

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'isuftin@usgs.gov'
 license          'Public domain'
 description      'Installs/Configures CIS STIG benchmarks'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.4'
+version          '0.6.5'
 source_url		 'https://github.com/USGS-CIDA/stig'
 issues_url		 'https://github.com/USGS-CIDA/stig/issues'
 

--- a/recipes/proc_hard.rb
+++ b/recipes/proc_hard.rb
@@ -1,31 +1,9 @@
 # Cookbook Name:: stig
 # Recipe:: proc_hard
-# Author: David Blodgett <dblodgett@usgs.gov>
+# Author: David Blodgett <dblodgett@usgs.gov>, Ivan Suftin <isuftin@usgs.gov>
 #
-# Description: Sets a few policies
-#
-# TODO: This recipe should probably be refactored into separate recipes for the 1.x.x and 4.x.x items
-#
-# RHEL6 (2.0.0) : 1.5.1
-# RHEL7 (2.0.0) : 1.5.1
-# CENTOS6 (2.0.0) : 1.5.1
-# CENTOS7 (2.0.0) : 1.5.1
-#
-# CIS Benchmark Items
-# RHEL6:  1.7.1, 1.7.2, 1.7.3, 4.1.1, 4.1.2, 4.2.2, 4.2.3, 4.2.4, 4.2.7, 4.4.2.2
-# CENTOS6: 1.6.3, 5.1.1, 5.1.2, 5.2.2, 5.2.3, 5.2.4, 5.2.7, 5.4.1.1, 5.4.1.2
-# UBUNTU: 4.1, 4.3, 7.1.1, 7.1.2, 7.2.2, 7.2.3, 7.2.4, 7.2.7, 7.3.1, 7.3.2, 7.3.3
-# - Restrict Core Dumps
-# - Enable Randomized Virtual Memory Region Placement
-# - Disable IP Forwarding
-# - Disable Send Packet Redirects
-# - Disable ICMP Redirect Acceptance
-# - Disable Secure ICMP Redirect Acceptance
-# - Log Suspicious Packets
-# - Enable RFC-recommended Source Route Validation
-# - Disable IPv6 Redirect Acceptance
-
-platform = node['platform']
+# Description: Updates sysctl policies using the third-party sysctl cookbook
+# and parameters specific to that cookbook coming from the default attributes.
 
 template '/etc/security/limits.conf' do
   source 'limits.conf.erb'
@@ -36,139 +14,12 @@ end
 
 package 'apport' do
   action :remove
-  only_if { %w(debian ubuntu).include? platform }
+  only_if { %w(debian ubuntu).include? node['platform'] }
 end
 
 package 'whoopsie' do
   action :remove
-  only_if { %w(debian ubuntu).include? platform }
+  only_if { %w(debian ubuntu).include? node['platform'] }
 end
 
 include_recipe 'sysctl::apply'
-
-ip_forwarding = node['stig']['network']['ip_forwarding']
-
-send_redirects = node['stig']['network']['packet_redirects']
-
-icmp_redirect_accept = node['stig']['network']['icmp_redirect_accept']
-
-log_suspicious_packets =  node['stig']['network']['log_suspicious_packets']
-
-rfc_source_route_validation = node['stig']['network']['rfc_source_route_validation']
-
-ipv6_redirect_accept = node['stig']['network']['ipv6_redirect_accept']
-
-icmp_all_secure_redirect_accept = node['stig']['network']['icmp_all_secure_redirect_accept']
-
-ipv6_ra_accept = node['stig']['network']['ipv6_ra_accept']
-
-execute 'sysctl_ip_forward' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.ip_forward=#{ip_forwarding}"
-  not_if "sysctl -e net.ipv4.ip_forward | grep -q #{ip_forwarding}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_send_redirects' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.all.send_redirects=#{send_redirects}"
-  not_if "sysctl -e net.ipv4.ip_forward | grep -q #{send_redirects}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_send_default_redirects' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.default.send_redirects=#{send_redirects}"
-  not_if "sysctl -e net.ipv4.conf.default.send_redirects | grep -q #{send_redirects}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_icmp_redirect_accept' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.all.accept_redirects=#{icmp_redirect_accept}"
-  not_if "sysctl -e net.ipv4.conf.all.accept_redirects | grep -q #{icmp_redirect_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_default_icmp_redirect_accept' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.default.accept_redirects=#{icmp_redirect_accept}"
-  not_if "sysctl -e net.ipv4.conf.default.accept_redirects | grep -q #{icmp_redirect_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_icmp_secure_redirect_accept' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.all.secure_redirects=#{icmp_all_secure_redirect_accept}"
-  not_if "sysctl -e net.ipv4.conf.all.secure_redirects | grep -q #{icmp_all_secure_redirect_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_default_icmp_secure_redirect_accept' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.default.secure_redirects=#{icmp_all_secure_redirect_accept}"
-  not_if "sysctl -e net.ipv4.conf.default.secure_redirects | grep -q #{icmp_all_secure_redirect_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_log_suspicious_packets' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.all.log_martians=#{log_suspicious_packets}"
-  not_if "sysctl -e net.ipv4.conf.all.log_martians | grep -q #{log_suspicious_packets}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_default_log_suspicious_packets' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.default.log_martians=#{log_suspicious_packets}"
-  not_if "sysctl -e net.ipv4.conf.default.log_martians | grep -q #{log_suspicious_packets}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_rfc_source_route_validation' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.all.rp_filter=#{rfc_source_route_validation}"
-  not_if "sysctl -e net.ipv4.conf.all.rp_filter | grep -q #{rfc_source_route_validation}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_default_rfc_source_route_validation' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv4.conf.default.rp_filter=#{rfc_source_route_validation}"
-  not_if "sysctl -e net.ipv4.conf.default.rp_filter | grep -q #{rfc_source_route_validation}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_ipv6_redirect_accept' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv6.conf.all.accept_redirects=#{ipv6_redirect_accept}"
-  not_if "sysctl -e net.ipv6.conf.all.accept_redirects | grep -q #{ipv6_redirect_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_default_ipv6_redirect_accept' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv6.conf.default.accept_redirects=#{ipv6_redirect_accept}"
-  not_if "sysctl -e net.ipv6.conf.default.accept_redirects | grep -q #{ipv6_redirect_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_ipv6_router_advertisement' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv6.conf.all.accept_ra=#{ipv6_ra_accept}"
-  not_if "sysctl -e net.ipv6.conf.all.accept_ra | grep -q #{ipv6_ra_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_default_ipv6_router_advertisement' do
-  user 'root'
-  command "/sbin/sysctl -e -w net.ipv6.conf.default.accept_ra=#{ipv6_ra_accept}"
-  not_if "sysctl -e net.ipv6.conf.default.accept_ra | grep -q #{ipv6_ra_accept}"
-  notifies :run, 'execute[sysctl_commit]', :delayed
-end
-
-execute 'sysctl_commit' do
-  user 'root'
-  command '/sbin/sysctl -e -p'
-  action :nothing
-end

--- a/spec/proc_hard_spec.rb
+++ b/spec/proc_hard_spec.rb
@@ -3,21 +3,8 @@ require 'spec_helper'
 describe 'stig::proc_hard' do
   let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
 
-  before do
-    stub_command('sysctl -e net.ipv4.ip_forward | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.default.send_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.all.accept_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.default.accept_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.all.secure_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.default.secure_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.all.log_martians | grep -q 1').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.default.log_martians | grep -q 1').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.all.rp_filter | grep -q 1').and_return(false)
-    stub_command('sysctl -e net.ipv4.conf.default.rp_filter | grep -q 1').and_return(false)
-    stub_command('sysctl -e net.ipv6.conf.all.accept_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv6.conf.default.accept_redirects | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv6.conf.all.accept_ra | grep -q 0').and_return(false)
-    stub_command('sysctl -e net.ipv6.conf.default.accept_ra | grep -q 0').and_return(false)
+  it 'includes the `sysctl::apply` recipe' do
+    expect(chef_run).to include_recipe('sysctl::apply')
   end
 
   it 'creates /etc/security/limits.conf template' do
@@ -37,75 +24,4 @@ describe 'stig::proc_hard' do
     expect(chef_run).to_not remove_package('whoopsie')
   end
 
-  it 'executes sysctl -e -w net.ipv4.ip_forward' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv4.ip_forward=0')
-  end
-
-  it 'executes sysctl -e -w net.ipv4.conf.default.send_redirects' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv4.conf.default.send_redirects=0')
-  end
-
-  it 'executes sysctl -e -w net.ipv4.conf.default.accept_redirects' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv4.conf.default.accept_redirects=0')
-  end
-
-  it 'executes sysctl -e -w net.ipv4.conf.default.secure_redirects' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv4.conf.default.secure_redirects=0')
-  end
-
-  it 'executes sysctl -e -w net.ipv4.conf.default.log_martians' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv4.conf.default.log_martians=1')
-  end
-
-  it 'executes sysctl -e -w net.ipv4.conf.default.rp_filter' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv4.conf.default.rp_filter=1')
-  end
-
-  it 'executes sysctl -e -w net.ipv6.conf.default.accept_redirects' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv6.conf.default.accept_redirects=0')
-  end
-
-  it 'executes sysctl -e -w net.ipv6.conf.all.accept_ra' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv6.conf.all.accept_ra=0')
-  end
-
-  it 'executes sysctl -e -w net.ipv6.conf.default.accept_ra' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv6.conf.default.accept_ra=0')
-  end
-
-  it 'Does not execute /sbin/sysctl -e -p' do
-    expect(chef_run).to_not run_execute('/sbin/sysctl -e -p')
-  end
-
-  it 'executes sysctl -e -w net.ipv6.conf.all.accept_ra' do
-    expect(chef_run).to run_execute('/sbin/sysctl -e -w net.ipv6.conf.all.accept_ra=0')
-  end
-
-  it 'excludes sysctl_send_redirects execution due to :nothing guard' do
-    expect(chef_run).to run_execute('sysctl_send_redirects')
-  end
-
-  it 'excludes sysctl_icmp_redirect_accept execution due to :nothing guard' do
-    expect(chef_run).to run_execute('sysctl_icmp_redirect_accept')
-  end
-
-  it 'excludes sysctl_icmp_secure_redirect_accept execution due to :nothing guard' do
-    expect(chef_run).to run_execute('sysctl_icmp_secure_redirect_accept')
-  end
-
-  it 'excludes sysctl_log_suspicious_packets execution due to :nothing guard' do
-    expect(chef_run).to run_execute('sysctl_log_suspicious_packets')
-  end
-
-  it 'excludes sysctl_rfc_source_route_validation execution due to :nothing guard' do
-    expect(chef_run).to run_execute('sysctl_rfc_source_route_validation')
-  end
-
-  it 'excludes sysctl_ipv6_redirect_accept execution due to :nothing guard' do
-    expect(chef_run).to run_execute('sysctl_ipv6_redirect_accept')
-  end
-
-  it 'excludes sysctl_ipv4_flush execution due to :nothing guard' do
-    expect(chef_run).to_not run_execute('sysctl_ipv4_flush')
-  end
 end


### PR DESCRIPTION
-- [isuftin@usgs.gov] - Leaving sysctl attribute mutation solely to the sysctl cookbook.

-- [isuftin@usgs.gov] - Removing STIG cookbook attributes for sysctl. Using only sysctl cookbook attributes