### PR TITLE
Update how the cookbook works with upstream sysctl cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,7 +4,7 @@ metadata
 
 cookbook 'auditd', '~> 2.2.0'
 cookbook 'logrotate', '~> 2.2.0'
-cookbook 'sysctl', '~> 0.10.2'
+cookbook 'sysctl'
 
 # The following is optional and only used if testing on the DOI network
 cookbook 'doi_ssl_filtering', github: 'USGS-CIDA/chef-cookbook-doi-ssl-filtering', tag: 'v1.0.6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ sysctl cookbook version >= 1.0.0
 -- [isuftin@usgs.gov] - Removed version constraint from Berksfile for sysctl
 -- [isuftin@usgs.gov] - Updated Chefspec test to remove test for sysctl::apply recipe
 -- [isuftin@usgs.gov] - Switched Changelog format
+-- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0
 
 ## [0.6.11]
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,50 @@
-## Changelog
----------
+# CHANGELOG
 
-- 0.6.11
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Updated
+-- [isuftin@usgs.gov] - proc_hard recipe now calls on the sysctl cookbook's
+sysctl_param resource instead of any recipe. This allows the this cookbook to use
+sysctl cookbook version >= 1.0.0
+-- [isuftin@usgs.gov] - Removed version constraint from Berksfile for sysctl
+-- [isuftin@usgs.gov] - Updated Chefspec test to remove test for sysctl::apply recipe
+-- [isuftin@usgs.gov] - Switched Changelog format
+
+## [0.6.11]
+### Updated
 -- [isuftin@usgs.gov] - Due to a change in the Chef client @ 13.7.16, the aide
 recipe needed to be updated. Also updated Rubocop, Chefspec and Foodcritic issues
 
-- 0.6.10
-
+## [0.6.10]
+### Added
 -- [jmorris@usgs.gov] - Added template for /etc/aide.conf and it updates the aide database
 -- [jmorris@usgs.gov] - Added default attributes for Centos 6 & 7 for /etc/aide.conf
 -- [jmorris@usgs.gov] - Added inspec and unit tests for /etc/aide.conf
+### Updated
 -- [jmorris@usgs.gov] - Corrected inspec tests centos7 to run aide tests for redhat platforms
 
-- 0.6.9
-
+## [0.6.9]
+### Updated
 -- [isuftin@usgs.gov] - Updated more audit not included in the last version
 -- [isuftin@usgs.gov] - Combined two audit steps into one to save time/processing
 
-- 0.6.8
-
+## [0.6.8]
+### Updated
 -- [isuftin@usgs.gov] - Updated audit scripts to not double-check file mounts that
 may appear twice in df output
 
-- 0.6.7
-
+## [0.6.7]
+### Updated
 -- [jmorris@usgs.gov] - Updated defaults for audit.rules to avoid 32/64 bit syscall mismatch warning
--- [jmorris@usgs.gov] - Removed "redhat" from the test for purging the avahi-daemon package
 -- [jmorris@usgs.gov] - Updated unit tests to work around errors
 -- [jmorris@usgs.gov] - Updated style tests for later version of foodcritic/rubocop
+### Removed
+-- [jmorris@usgs.gov] - Removed "redhat" from the test for purging the avahi-daemon package
 
-- 0.6.6
-
+## [0.6.6]
+### Updated
 -- [isuftin@usgs.gov] - Updating the cookbook to work properly with CentOS 7
 -- [isuftin@usgs.gov] - Added disabling vfat and ipv6 to modprobe
 -- [isuftin@usgs.gov] - Update avahi daemon recipe for CentOS 7 (chkconfig vs sysctl)
@@ -46,92 +59,107 @@ may appear twice in df output
 -- [isuftin@usgs.gov] - Split InSpec tests into CentOS 6 and CentOS 7
 -- [isuftin@usgs.gov] - Updated Gemfile to require a minimal inspec gem version
 
-- 0.6.5
-
+## [0.6.5]
+### Updated
 -- [isuftin@usgs.gov] - Leaving sysctl attribute mutation solely to the sysctl cookbook.
 -- [isuftin@usgs.gov] - Removing STIG cookbook attributes for sysctl. Using only sysctl cookbook attributes
 
-- 0.6.4
-
+## [0.6.4]
+### Updated
 -- [isuftin@usgs.gov] - Update mail transfer agent recipe to fully parameterize the CentOS template for main.cf
 
-- 0.6.3
-
+## [0.6.3]
+### Updated
 -- [isuftin@usgs.gov] - Update the system_auth recipe to respect pre-existing symlinks
 -- [isuftin@usgs.gov] - Fix boot_settings recipe to catch if selinux is disabled and move on
 
-- 0.6.2
-
+## [0.6.2]
+### Updated
 -- [isuftin@usgs.gov] - More testing
 -- [isuftin@usgs.gov] - Updated auditd ruleset to include more rules
 -- [isuftin@usgs.gov] - Created ChefSpec testing for auditd_rules recipe
 -- [isuftin@usgs.gov] - Updated ServerSpec testing for all default auditd rules
 
-- 0.6.1
+## [0.6.1]
+### Updated
 -- [isuftin@usgs.gov] - More rubocop fixes
 -- [isuftin@usgs.gov] - Rework of sshd_config recipe to allow more customization
 -- [isuftin@usgs.gov] - Updated templates to point to proper GitHub URL
 -- [isuftin@usgs.gov] - Updated dependency version for sysctl cookbook in Berksfile
 -- [isuftin@usgs.gov] - Fixed kitchen converge warnings
 
-- 0.6.0
+## [0.6.0]
+### Updated
 -- [steve@bigsteve.us] - fix some rubocop violations
 -- [steve@bigsteve.us] - switch to using chef inspec
 -- [steve@bigsteve.us] - remove Centos 6.6 and 6.8  
 -- [steve@bigsteve.us] - bump version to 0.6.0
 -- [steve@bigsteve.us] - remove kitchen version pin.
 
-- 0.5.5
+## [0.5.5]
+### Updated
 -- [arothian@github] - Update aide to setup crontab for ubuntu
 
-- 0.5.4
+## [0.5.4]
+### Updated
 -- [isuftin@usgs.gov] - Fix an issue with auth-config being improperly written to for pass reuse limit
 
-- 0.5.3
+## [0.5.3]
+### Updated
 -- [isuftin@usgs.gov] - Switch sysctl write flags
 
-- 0.5.2
+## [0.5.2]
+### Updated
 -- [isuftin@usgs.gov] - Ignore errors on unknown sysctl keys
 
-- 0.5.1
+## [0.5.1]
+### Updated
 -- [isuftin@usgs.gov] - Included third-party sysctl cookbook as a hard-coupled dependency by calling it in proc_hard recipe
 
-- 0.5.0
+## [0.5.0]
+### Updated
 -- [isuftin@usgs.gov] - Switched sysctl.conf template writing out and brought in the third-party sysctl cookbook to handle writing .d config file
 -- [isuftin@usgs.gov] - Updated serverspec testing
 
-- 0.4.3
+## [0.4.3]
+### Updated
 -- [isuftin@usgs.gov] - Updated to switch out which file in /etc/pam.d/system-auth* gets symlinked
 
-- 0.4.2
+## [0.4.2]
+### Updated
 -- [isuftin@usgs.gov] - Fix most foodcritic errors and warnings
 -- [isuftin@usgs.gov] - CIS 1.6.2 (Configure ExecShield) was removed in 2.0.0 of all CIS STIG. No longer testing for it
 -- [isuftin@usgs.gov] - Added updates to SSHD config to allow boolean for password authentication
 -- [isuftin@usgs.gov] - Updated system auth recipe to be less destructive to /etc/pam.d/system-auth since that may be updated by authconfig
 -- [isuftin@usgs.gov] - Fixed a few tests
 
-
-- 0.4.1
+## [0.4.1]
+### Updated
 -- [isuftin@usgs.gov] - Updated sshd config to include approved ciphers (RHEL6 STIG 6.2.11)
 -- [isuftin@usgs.gov] - Added the ability to change `ChallengeResponseAuthentication` in sshd config
 -- [isuftin@usgs.gov] - Added the ability to change `UsePAM` in sshd config
 
-- 0.4.0
+## [0.4.0]
+### Updated
 -- [isuftin@usgs.gov] - Users may now add auditd rules directly as a series of attributes
 
-- 0.3.11
+## [0.3.11]
+### Updated
 -- [isuftin@usgs.gov] - More Auditd fixes
 
-- 0.3.10
+## [0.3.10]
+### Updated
 -- [isuftin@usgs.gov] - Fix auditd default parameters which break the build
 -- [isuftin@usgs.gov] - Add documentation for new attributes
 
-- 0.3.9
+## [0.3.9]
+### Updated
 -- [isuftin@usgs.gov] - Fully parameterized auditd configuration file
 -- [isuftin@usgs.gov] - No longer calling the auditd cookbook directly from auditd.rb
 -- [isuftin@usgs.gov] - Auditd cookbook is no longer a direct dependency of the STIG cookbook. Should be part of an overall runlist
 
-- 0.3.8
+## [0.3.8]
+### Updated
 -- [isuftin@usgs.gov] - Updated STIG and Audit rules to CIS RHEL Stig 1.4.0
 -- [isuftin@usgs.gov] - Added CentOS 6 ruleset 3.2 - "Remove the X Window System"
 -- [isuftin@usgs.gov] - Fixed and added many Serverspec tests

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -770,63 +770,63 @@ default['stig']['sshd_config']['kerberos_authentication'] = 'no'
 # Default is 'yes' (true)
 default['stig']['sshd_config']['kerberos_or_local_passwd'] = 'yes'
 
-# Specifies whether to automatically	destroy	the user's ticket cache file on logout.
+# Specifies whether to automatically  destroy  the user's ticket cache file on logout.
 # Default is 'yes' (true)
 default['stig']['sshd_config']['kerberos_ticket_cleanup'] = 'yes'
 
 # Specifies whether to look at .k5login file for user's aliases
 default['stig']['sshd_config']['kerberos_use_kuserok'] = 'yes'
 
-# In protocol version 1, the	ephemeral server key is	automatically
-# regenerated after this many seconds (if it	has been used).	 The
-# purpose of	regeneration is	to prevent decrypting captured sessions by
+# In protocol version 1, the  ephemeral server key is  automatically
+# regenerated after this many seconds (if it  has been used).   The
+# purpose of  regeneration is  to prevent decrypting captured sessions by
 # later breaking into the machine and stealing the keys.
-# The key is	never stored anywhere.	If the value is	0, the key is
-# never regenerated.	 The default is	3600 (seconds).
+# The key is  never stored anywhere.  If the value is  0, the key is
+# never regenerated.   The default is  3600 (seconds).
 default['stig']['sshd_config']['key_regeneration_interval'] = 3600
 
-# The server disconnects after this time if the user has not	successfully logged
-# in.  If the value	is 0, there is no time limit. The default is 120 seconds.
+# The server disconnects after this time if the user has not  successfully logged
+# in.  If the value  is 0, there is no time limit. The default is 120 seconds.
 default['stig']['sshd_config']['login_grace_time'] = 120
 
-# Specifies the port	number that sshd listens on.  The default is
+# Specifies the port  number that sshd listens on.  The default is
 # 22.  Multiple options of this type are permitted
 default['stig']['sshd_config']['port'] = %w[22]
 
 # Specifies whether sshd should print the date and time when the user last logged in.
 default['stig']['sshd_config']['print_last_log'] = 'yes'
 
-# Specifies whether sshd should print /etc/motd when	a user logs in
-# interactively.  (On some systems it is also printed by the	shell,
+# Specifies whether sshd should print /etc/motd when  a user logs in
+# interactively.  (On some systems it is also printed by the  shell,
 # /etc/profile, or equivalent.)
 default['stig']['sshd_config']['print_motd'] = 'yes'
 
 # Specifies whether public key authentication is allowed.
-# Note that this option	applies	to protocol version 2 only
+# Note that this option  applies  to protocol version 2 only
 default['stig']['sshd_config']['pub_key_authentication'] = 'yes'
 
 # Gives the verbosity level that is used when logging messages from
-# sshd.  The	possible values	are: QUIET, FATAL, ERROR, INFO,	VER-
+# sshd.  The  possible values  are: QUIET, FATAL, ERROR, INFO,  VER-
 # BOSE, DEBUG, DEBUG1, DEBUG2 and DEBUG3.  The default is INFO.
 # DEBUG and DEBUG1 are equivalent.  DEBUG2 and DEBUG3 each specify
-# higher levels of debugging	output.	 Logging with a	DEBUG level
+# higher levels of debugging  output.   Logging with a  DEBUG level
 # violates the privacy of users and is not recommended.
 default['stig']['sshd_config']['log_level'] = 'INFO'
 
 # Specifies the available MAC (message authentication code) algorithms.
-# The MAC algorithm	is used	in protocol version 2 for data integrity protection.
-# Multiple algorithms	must be	comma-separated.
+# The MAC algorithm  is used  in protocol version 2 for data integrity protection.
+# Multiple algorithms  must be  comma-separated.
 default['stig']['sshd_config']['macs'] = 'hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96'
 
-# Specifies the maximum number of concurrent	unauthenticated	connections to the
+# Specifies the maximum number of concurrent  unauthenticated  connections to the
 # sshd daemon.  Additional connections will be dropped until authentication succeeds
-# or the LoginGraceTime expires for a connection.	The default is 10:30:60.
+# or the LoginGraceTime expires for a connection.  The default is 10:30:60.
 #
-# Alternatively, random early drop can be enabled by	specifying the
+# Alternatively, random early drop can be enabled by  specifying the
 # three colon separated values ``start:rate:full'' (e.g.,
-# "10:30:60").  sshd	will refuse connection attempts	with a probability of
+# "10:30:60").  sshd  will refuse connection attempts  with a probability of
 # 'rate/100' (30%) if there are currently 'start' (10) unauthenticated connections.
-# The probability	increases linearly and all connection attempts are refused if
+# The probability  increases linearly and all connection attempts are refused if
 # the number of unauthenticated connections reaches 'full' (60).
 default['stig']['sshd_config']['max_startups'] = '10:30:60'
 
@@ -852,15 +852,15 @@ default['stig']['sshd_config']['password_authentication'] = 'yes'
 
 # Specifies whether rhosts or /etc/hosts.equiv authentication
 # together with successful RSA host authentication is allowed
-# This option applies to	protocol version 1 only.
+# This option applies to  protocol version 1 only.
 default['stig']['sshd_config']['rhosts_rsa_authentication'] = 'no'
 
-# Specifies whether pure RSA	authentication is allowed.
-# This option applies to	protocol version 1 only.
+# Specifies whether pure RSA  authentication is allowed.
+# This option applies to  protocol version 1 only.
 default['stig']['sshd_config']['rsa_authentication'] = 'no'
 
-# Defines the number	of bits	in the ephemeral protocol version 1
-# server key.  The minimum value is 512, and	the default is 768
+# Defines the number  of bits  in the ephemeral protocol version 1
+# server key.  The minimum value is 512, and  the default is 768
 default['stig']['sshd_config']['server_key_bits'] = 768
 
 # Specifies whether sshd will display the patch level of the binary in the
@@ -868,110 +868,110 @@ default['stig']['sshd_config']['server_key_bits'] = 768
 # The default is 'no' (false). This option applies to protocol version 1 only.
 default['stig']['sshd_config']['show_patch_level'] = 'no'
 
-# Specifies whether sshd should check file modes and	ownership of
-# the user's files and home directory before	accepting login.  This
-# is	normally desirable because novices sometimes accidentally
+# Specifies whether sshd should check file modes and  ownership of
+# the user's files and home directory before  accepting login.  This
+# is  normally desirable because novices sometimes accidentally
 # leave their directory or files world-writable.
 default['stig']['sshd_config']['strict_modes'] = 'yes'
 
-# Configures	an external subsystem (e.g., file transfer daemon).
-# Arguments should be a subsystem name and a	command	to execute
+# Configures  an external subsystem (e.g., file transfer daemon).
+# Arguments should be a subsystem name and a  command  to execute
 # upon subsystem request.  The command sftp-server implements
-# the ``sftp'' file transfer	subsystem.  By default no subsystems
-# are defined.  Note	that this option applies to protocol version 2
+# the ``sftp'' file transfer  subsystem.  By default no subsystems
+# are defined.  Note  that this option applies to protocol version 2
 # only.
-default['stig']['sshd_config']['subsystem'] = 'sftp	/usr/libexec/openssh/sftp-server'
+default['stig']['sshd_config']['subsystem'] = 'sftp  /usr/libexec/openssh/sftp-server'
 
-# Gives the facility	code that is used when logging messages	from
-# sshd.  The	possible values	are: DAEMON, USER, AUTH, LOCAL0,
+# Gives the facility  code that is used when logging messages  from
+# sshd.  The  possible values  are: DAEMON, USER, AUTH, LOCAL0,
 # LOCAL1, LOCAL2, LOCAL3, LOCAL4, LOCAL5, LOCAL6, LOCAL7.  The
-# default is	AUTHPRIV.
+# default is  AUTHPRIV.
 default['stig']['sshd_config']['syslog_facility'] = 'AUTHPRIV'
 
 # Specifies whether the system should send TCP keepalive messages
-# to	the other side.	 If they are sent, death of the	connection or
+# to  the other side.   If they are sent, death of the  connection or
 # crash of one of the machines will be properly noticed.  However,
-# this means	that connections will die if the route is down tempo-
-# rarily, and some people find it annoying.	On the other hand, if
-# TCP keepalives are	not sent, sessions may hang indefinitely on
+# this means  that connections will die if the route is down tempo-
+# rarily, and some people find it annoying.  On the other hand, if
+# TCP keepalives are  not sent, sessions may hang indefinitely on
 # the server, leaving 'ghost' users and consuming server
 # resources.
 #
-# The default is 'yes' (true) (to	send TCP keepalive messages), and the
-# server will notice	if the network goes down or the	client host
+# The default is 'yes' (true) (to  send TCP keepalive messages), and the
+# server will notice  if the network goes down or the  client host
 # crashes.  This avoids infinitely hanging sessions.
 #
-# To	disable	TCP keepalive messages,	the value should be set	to
+# To  disable  TCP keepalive messages,  the value should be set  to
 # 'no' (false).
 default['stig']['sshd_config']['tcp_keepalive'] = 'yes'
 
 # Specifies whether sshd should lookup the remote host name and
-# check that	the resolved host name for the remote IP address maps
+# check that  the resolved host name for the remote IP address maps
 # back to the very same IP address.
 default['stig']['sshd_config']['use_dns'] = 'no'
 
-# Specifies whether login is used	for interactive	login sessions.
-# The default is 'no' (false).  Note that login	is never used
-# for remote	command	execution.  Note also, that if this is
+# Specifies whether login is used  for interactive  login sessions.
+# The default is 'no' (false).  Note that login  is never used
+# for remote  command  execution.  Note also, that if this is
 # enabled, X11Forwarding will be disabled because login does not
-# know how to handle	xauth cookies.  If UsePrivilegeSeparation
-# is	specified, it will be disabled after authentication.
+# know how to handle  xauth cookies.  If UsePrivilegeSeparation
+# is  specified, it will be disabled after authentication.
 default['stig']['sshd_config']['use_login'] = 'no'
 
 # Specifies whether sshd separates privileges by creating an
-# unprivileged child	process	to deal	with incoming network traffic.
+# unprivileged child  process  to deal  with incoming network traffic.
 # After successful authentication, another process will be created
-# that has the privilege of the authenticated user.	The goal of
-# privilege separation is to	prevent	privilege escalation by	containing
-# any corruption within the unprivileged processes.	The
-# default is	'yes' (true).
+# that has the privilege of the authenticated user.  The goal of
+# privilege separation is to  prevent  privilege escalation by  containing
+# any corruption within the unprivileged processes.  The
+# default is  'yes' (true).
 default['stig']['sshd_config']['use_privilege_separation'] = 'yes'
 
-# Specifies a string	to append to the regular version string	to
+# Specifies a string  to append to the regular version string  to
 # identify OS- or site-specific modifications.
 default['stig']['sshd_config']['version_addendum'] = ''
 
-# Specifies the first display number	available for sshd's X11 forwarding.
-# This prevents sshd from interfering with	real X11 servers.
+# Specifies the first display number  available for sshd's X11 forwarding.
+# This prevents sshd from interfering with  real X11 servers.
 default['stig']['sshd_config']['x_11_display_offset'] = 10
 
 # Specifies whether X11 forwarding is permitted.  The argument must
-# be	'yes'	(true) or 'no' (false).  The	default	is 'yes'.
+# be  'yes'  (true) or 'no' (false).  The  default  is 'yes'.
 #
 # When X11 forwarding is enabled, there may be additional exposure
-# to	the server and to client displays if the sshd proxy display is
-# configured	to listen on the wildcard address (see X11UseLocalhost
+# to  the server and to client displays if the sshd proxy display is
+# configured  to listen on the wildcard address (see X11UseLocalhost
 # below), however this is not the default.  Additionally, the
-# authentication spoofing and authentication	data verification and
-# substitution occur	on the client side.  The security risk of
+# authentication spoofing and authentication  data verification and
+# substitution occur  on the client side.  The security risk of
 # using X11 forwarding is that the clients X11 display server may
-# be	exposed	to attack when the ssh client requests forwarding (see
+# be  exposed  to attack when the ssh client requests forwarding (see
 # the warnings for ForwardX11 in ssh_config).  A system administrator
-# may	have a stance in which they want to protect clients
-# that may expose themselves	to attack by unwittingly requesting
+# may  have a stance in which they want to protect clients
+# that may expose themselves  to attack by unwittingly requesting
 # X11 forwarding, which can warrant a 'no' setting.
 #
-# Note that disabling X11 forwarding	does not prevent users from
-# forwarding	X11 traffic, as	users can always install their own
+# Note that disabling X11 forwarding  does not prevent users from
+# forwarding  X11 traffic, as  users can always install their own
 # forwarders.  X11 forwarding is automatically disabled if UseLogin
-# is	enabled.
+# is  enabled.
 default['stig']['sshd_config']['x_11_forwarding'] = 'yes'
 
-# Specifies whether sshd should bind	the X11	forwarding server to
-# the loopback address or to	the wildcard address.  By default,
-# sshd binds	the forwarding server to the loopback address and sets
+# Specifies whether sshd should bind  the X11  forwarding server to
+# the loopback address or to  the wildcard address.  By default,
+# sshd binds  the forwarding server to the loopback address and sets
 # the hostname part of the DISPLAY environment variable to
-# 'localhost'.  This prevents remote hosts	from connecting	to the
+# 'localhost'.  This prevents remote hosts  from connecting  to the
 # proxy display.  However, some older X11 clients may not function
 # with this configuration.  X11UseLocalhost may be set to 'no' to
-# specify that the forwarding server	should be bound	to the wildcard
-# address.  The	argument must be 'yes' (true) or 'no' (false).
+# specify that the forwarding server  should be bound  to the wildcard
+# address.  The  argument must be 'yes' (true) or 'no' (false).
 default['stig']['sshd_config']['x_11_use_local_host'] = 'yes'
 
-# Specifies the full	pathname of the	xauth program
+# Specifies the full  pathname of the  xauth program
 default['stig']['sshd_config']['x_auth_location'] = ''
 
-# Specifies the file	that contains the process ID of	the sshd daemon
+# Specifies the file  that contains the process ID of  the sshd daemon
 default['stig']['sshd_config']['pid_file'] = '/var/run/sshd.pid'
 
 # Allow Users to Set Environment Options
@@ -1014,7 +1014,7 @@ default['stig']['sshd_config']['allow_agent_forwarding'] = 'yes'
 
 default['stig']['sshd_config']['allow_users'] = []
 default['stig']['sshd_config']['allow_groups'] = []
-# Specifies what environment	variables sent by the client will be copied into
+# Specifies what environment  variables sent by the client will be copied into
 # the session's environ
 # see: https://www.freebsd.org/cgi/man.cgi?query=environ&sektion=7&apropos=0&manpath=FreeBSD+11.0-RELEASE+and+Ports
 default['stig']['sshd_config']['accept_env'] = %w[
@@ -1045,9 +1045,9 @@ default['stig']['sshd_config']['address_family'] = 'any'
 # ListenAddress host|IPv4_addr:port
 # ListenAddress [host|IPv6_addr]:port
 #
-# If	port is	not specified, sshd will listen	on the address and all
-# Port options specified.  The default is to	listen on all local
-# addresses.	 Multiple ListenAddress	options	are permitted.
+# If  port is  not specified, sshd will listen  on the address and all
+# Port options specified.  The default is to  listen on all local
+# addresses.   Multiple ListenAddress  options  are permitted.
 default['stig']['sshd_config']['listen_address'] = %w[0.0.0.0]
 
 # Specifies the protocol versions sshd supports. (String), Default: 2

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,14 +5,14 @@ license          'CPL-1.0'
 description      'Installs/Configures CIS STIG benchmarks'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.6.11'
-source_url		 'https://github.com/USGS-CIDA/stig'
-issues_url		 'https://github.com/USGS-CIDA/stig/issues'
+source_url       'https://github.com/USGS-CIDA/stig'
+issues_url       'https://github.com/USGS-CIDA/stig/issues'
 
 supports         'centos', '>= 6.6'
 supports         'centos', '>= 7.1'
 supports         'ubuntu'
 
-chef_version '>= 12.0.0'
+chef_version     '>= 12.0.0'
 
-depends			 'logrotate'
-depends			 'sysctl'
+depends          'logrotate'
+depends          'sysctl'

--- a/recipes/proc_hard.rb
+++ b/recipes/proc_hard.rb
@@ -22,4 +22,8 @@ package 'whoopsie' do
   only_if { %w[debian ubuntu].include? node['platform'] }
 end
 
-include_recipe 'sysctl::apply'
+node['sysctl']['params'].each do |param, value|
+  sysctl_param param do
+    value value
+  end
+end

--- a/spec/ipv6_spec.rb
+++ b/spec/ipv6_spec.rb
@@ -57,7 +57,7 @@ describe 'stig::ipv6 CentOS 7.x' do
     expect(chef_run).to start_service("iptables")
   end
 
-  it 'Executes start_ip6tables' do
+  it 'Does not execute start_ip6tables' do
     expect(chef_run).to_not start_service("ip6tables")
   end
 end

--- a/spec/proc_hard_spec.rb
+++ b/spec/proc_hard_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 describe 'stig::proc_hard CentOS 7.x' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge('stig::proc_hard') }
 
-  it 'includes the `sysctl::apply` recipe' do
-    expect(chef_run).to include_recipe('sysctl::apply')
-  end
-
   it 'creates /etc/security/limits.conf template' do
     expect(chef_run).to create_template('/etc/security/limits.conf').with(
       source: 'limits.conf.erb',
@@ -30,10 +26,6 @@ end
 
 describe 'stig::proc_hard CentOS 6.x' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '6.7').converge('stig::proc_hard') }
-
-  it 'includes the `sysctl::apply` recipe' do
-    expect(chef_run).to include_recipe('sysctl::apply')
-  end
 
   it 'creates /etc/security/limits.conf template' do
     expect(chef_run).to create_template('/etc/security/limits.conf').with(


### PR DESCRIPTION
-- [isuftin@usgs.gov] - proc_hard recipe now calls on the sysctl cookbook's
sysctl_param resource instead of any recipe. This allows the this cookbook to use
sysctl cookbook version >= 1.0.0
-- [isuftin@usgs.gov] - Removed version constraint from Berksfile for sysctl
-- [isuftin@usgs.gov] - Updated Chefspec test to remove test for sysctl::apply recipe
-- [isuftin@usgs.gov] - Switched Changelog format
-- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0