### PR TITLE
Mail Transfer Agent Bug on Redhat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ sysctl cookbook version >= 1.0.0
 -- [isuftin@usgs.gov] - Added boolean flag to sysctl parameters to ignore errors (defaults to true)
 -- [isuftin@usgs.gov] - Switched Changelog format
 -- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0
+-- [cpoma@mitre.org] - Bugfix in stig/recipes/mail_transfer_agent.rb to use platform_family versus platform
 
 ## [0.6.11]
 ### Updated

--- a/recipes/mail_transfer_agent.rb
+++ b/recipes/mail_transfer_agent.rb
@@ -10,13 +10,15 @@
 # Ubuntu 6.15
 
 source = ''
-if %w[rhel fedora centos].include?(node['platform'])
-  source = 'etc_main.cf_rhel.erb'
-end
+# Fixed to check platform_family versus platform
+#    'redhat', 'fedora', 'centos' are platforms;
+#    'rhel' is the platform_family that includes those platforms
+source = 'etc_main.cf_rhel.erb' if node['platform_family'] == 'rhel'
 
-if %w[debian ubuntu].include?(node['platform'])
-  source = 'etc_main.cf_ubuntu.erb'
-end
+# Fixed to check platform_family versus platform
+#    'debian', 'ubuntu', 'linuxmint' are platforms;
+#    'debian' is the platform_family that includes those platforms
+source = 'etc_main.cf_ubuntu.erb' if node['platform_family'] == 'debian'
 
 template '/etc/postfix/main.cf' do
   source source


### PR DESCRIPTION
Bugfix in stig/recipes/mail_transfer_agent.rb to use platform_family versus platform. This fixes Issue #109 