### PR TITLE
SSHD FIPS Mode MACs Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ sysctl cookbook version >= 1.0.0
 -- [isuftin@usgs.gov] - Added boolean flag to sysctl parameters to ignore errors (defaults to true)
 -- [isuftin@usgs.gov] - Switched Changelog format
 -- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0
+-- [cpoma@mitre.org] - Bugfix in stig/recipes/mail_transfer_agent.rb to use platform_family versus platform
 
 ## [0.6.11]
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ sysctl cookbook version >= 1.0.0
 -- [isuftin@usgs.gov] - Added boolean flag to sysctl parameters to ignore errors (defaults to true)
 -- [isuftin@usgs.gov] - Switched Changelog format
 -- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0
+### Fixed
 -- [cpoma@mitre.org] - Bugfix in stig/recipes/mail_transfer_agent.rb to use platform_family versus platform
+-- [cpoma@mitre.org] - Bugfix in stig/attributes/default.rb - Errors out and sshd dies (bricking machine) on RH 7 
+when FIPS Mode is enabled. Non-FIPS compliant MACs were specified. FIPS MODE is required to be enabled - RHEL-07-021350 - CCI-002476
+Old Line: default['stig']['sshd_config']['macs'] = 'hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96'
+Replaced with: default['stig']['sshd_config']['macs'] = 'hmac-sha2-512,hmac-sha2-256'
+See https://people.redhat.com/swells/scap-security-guide/tables/table-rhel7-stig.html
+See http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf
+
 
 ## [0.6.11]
 ### Updated

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -820,7 +820,7 @@ default['stig']['sshd_config']['log_level'] = 'INFO'
 # Specifies the available MAC (message authentication code) algorithms.
 # The MAC algorithm  is used  in protocol version 2 for data integrity protection.
 # Multiple algorithms  must be  comma-separated.
-default['stig']['sshd_config']['macs'] = 'hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96'
+default['stig']['sshd_config']['macs'] = 'hmac-sha2-256,hmac-sha2-512'
 
 # Specifies the maximum number of concurrent  unauthenticated  connections to the
 # sshd daemon.  Additional connections will be dropped until authentication succeeds

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -820,7 +820,7 @@ default['stig']['sshd_config']['log_level'] = 'INFO'
 # Specifies the available MAC (message authentication code) algorithms.
 # The MAC algorithm  is used  in protocol version 2 for data integrity protection.
 # Multiple algorithms  must be  comma-separated.
-default['stig']['sshd_config']['macs'] = 'hmac-sha2-256,hmac-sha2-512'
+default['stig']['sshd_config']['macs'] = 'hmac-sha2-512,hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com'
 
 # Specifies the maximum number of concurrent  unauthenticated  connections to the
 # sshd daemon.  Additional connections will be dropped until authentication succeeds

--- a/recipes/mail_transfer_agent.rb
+++ b/recipes/mail_transfer_agent.rb
@@ -10,15 +10,13 @@
 # Ubuntu 6.15
 
 source = ''
-# Fixed to check platform_family versus platform
-#    'redhat', 'fedora', 'centos' are platforms;
-#    'rhel' is the platform_family that includes those platforms
-source = 'etc_main.cf_rhel.erb' if node['platform_family'] == 'rhel'
+if %w[rhel fedora centos].include?(node['platform'])
+  source = 'etc_main.cf_rhel.erb'
+end
 
-# Fixed to check platform_family versus platform
-#    'debian', 'ubuntu', 'linuxmint' are platforms;
-#    'debian' is the platform_family that includes those platforms
-source = 'etc_main.cf_ubuntu.erb' if node['platform_family'] == 'debian'
+if %w[debian ubuntu].include?(node['platform'])
+  source = 'etc_main.cf_ubuntu.erb'
+end
 
 template '/etc/postfix/main.cf' do
   source source

--- a/recipes/mail_transfer_agent.rb
+++ b/recipes/mail_transfer_agent.rb
@@ -10,13 +10,15 @@
 # Ubuntu 6.15
 
 source = ''
-if %w[rhel fedora centos].include?(node['platform'])
-  source = 'etc_main.cf_rhel.erb'
-end
+# Fixed to check platform_family versus platform
+#    'redhat', 'fedora', 'centos' are platforms;
+#    'rhel' is the platform_family that includes those platforms
+source = 'etc_main.cf_rhel.erb' if node['platform_family'] == 'rhel'
 
-if %w[debian ubuntu].include?(node['platform'])
-  source = 'etc_main.cf_ubuntu.erb'
-end
+# Fixed to check platform_family versus platform
+#    'debian', 'ubuntu', 'linuxmint' are platforms;
+#    'debian' is the platform_family that includes those platforms
+source = 'etc_main.cf_ubuntu.erb' if node['platform_family'] == 'debian'
 
 template '/etc/postfix/main.cf' do
   source source


### PR DESCRIPTION
Bugfix in stig/attributes/default.rb - Errors out and sshd dies (bricking machine) on RH 7 when FIPS Mode is enabled. Non-FIPS compliant MACs were specified. FIPS MODE is required to be enabled - RHEL-07-021350 - CCI-002476
Old Line: default['stig']['sshd_config']['macs'] = 'hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96'
Replaced with: default['stig']['sshd_config']['macs'] = 'hmac-sha2-512,hmac-sha2-256'
See https://people.redhat.com/swells/scap-security-guide/tables/table-rhel7-stig.html
See http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf