### PR TITLE
Fully Disable VFAT file system and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ sysctl cookbook version >= 1.0.0
 -- [cpoma@mitre.org] - Bugfix in stig/attributes/default.rb - Errors out and sshd dies (bricking machine) on RH 7 
 when FIPS Mode is enabled. Non-FIPS compliant MACs were specified. FIPS MODE is required to be enabled - RHEL-07-021350 - CCI-002476
 Old Line: default['stig']['sshd_config']['macs'] = 'hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96'
-Replaced with: default['stig']['sshd_config']['macs'] = 'hmac-sha2-512,hmac-sha2-256'
+Replaced with: default['stig']['sshd_config']['macs'] = 'hmac-sha2-512,hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com'
 See https://people.redhat.com/swells/scap-security-guide/tables/table-rhel7-stig.html
 See http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf
-
+- [cpoma@mitre.org] - Added "install fat /bin/true" to stig/templates/etc_modprobe.d_CIS.conf.erb. This will fully disable vfat.
 
 ## [0.6.11]
 ### Updated

--- a/templates/default/etc_modprobe.d_CIS.conf.erb
+++ b/templates/default/etc_modprobe.d_CIS.conf.erb
@@ -35,6 +35,7 @@ install udf /bin/true
 
 <% if node["stig"]["mount_disable"]["vfat"] -%>
 install vfat /bin/true
+install fat /bin/true
 <% end -%>
 
 <% if node["stig"]["network"]["disable_dcpp"] -%>


### PR DESCRIPTION
Added "install fat /bin/true" to stig/templates/etc_modprobe.d_CIS.conf.erb. This will fully disable vfat. vfat depends on fat subsystem.

```bash
[root@server tmp]# modinfo vfat
filename:       /lib/modules/3.10.0-693.11.6.el7.x86_64/kernel/fs/fat/vfat.ko.xz
author:         Gordon Chaffee
description:    VFAT filesystem support
license:        GPL
alias:          fs-vfat
rhelversion:    7.4
srcversion:     A3254796A3CD9815ABDDC94
depends:        fat
intree:         Y
vermagic:       3.10.0-693.11.6.el7.x86_64 SMP mod_unload modversions
signer:         Red Hat Enterprise Linux kernel signing key
sig_key:        5F:D8:EB:CF:C4:C5:20:3C:3C:B7:90:52:19:FB:66:9D:5F:4B:E3:FF
sig_hashalgo:   sha256
```
Depends on "fat" so we should kill off the loading of fat too.

```bash
[ec2-user@server tmp]$ modinfo fat
filename:       /lib/modules/3.10.0-693.11.6.el7.x86_64/kernel/fs/fat/fat.ko.xz
license:        GPL
rhelversion:    7.4
srcversion:     48C5E88500B6EBB832D91D7
depends:
intree:         Y
vermagic:       3.10.0-693.11.6.el7.x86_64 SMP mod_unload modversions
signer:         Red Hat Enterprise Linux kernel signing key
sig_key:        5F:D8:EB:CF:C4:C5:20:3C:3C:B7:90:52:19:FB:66:9D:5F:4B:E3:FF
sig_hashalgo:   sha256
[root@server tmp]# ls -l /lib/modules/$(uname -r)/kernel/fs | grep fat
drwxr-xr-x. 2 root root   57 Jan  8 11:57 fat

[ec2-user@chefcomplianceserver ~]$ cat /lib/modules/$(uname -r)/modules.dep | grep fat
kernel/fs/fat/fat.ko.xz:
kernel/fs/fat/vfat.ko.xz: kernel/fs/fat/fat.ko.xz
kernel/fs/fat/msdos.ko.xz: kernel/fs/fat/fat.ko.xz

```