### PR TITLE
CRON Permissions Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ sysctl cookbook version >= 1.0.0
 -- [isuftin@usgs.gov] - Add guard to sysctl call in order to work around bug https://github.com/chef/chef/issues/7189
 -- [isuftin@usgs.gov] - Switched Changelog format
 -- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0
+-- [cpoma@mitre.org] - Add /var/spool/cron for folder permission management and an ERB file template for /etc/cron.allow to recipes/file_permissions.rb
 ### Fixed
 -- [cpoma@mitre.org] - Bugfix in stig/recipes/mail_transfer_agent.rb to use platform_family versus platform
 -- [cpoma@mitre.org] - Bugfix in stig/attributes/default.rb - Errors out and sshd dies (bricking machine) on RH 7

--- a/recipes/file_permissions.rb
+++ b/recipes/file_permissions.rb
@@ -34,7 +34,7 @@
   end
 end
 
-%w[/etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d].each do |d|
+%w[/etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly /etc/cron.d /var/spool/cron].each do |d|
   directory d do
     owner 'root'
     group 'root'
@@ -65,11 +65,12 @@ file '/etc/at.allow' do
   action :create
 end
 
-file '/etc/cron.allow' do
-  mode 0o600
-  owner 'root'
-  group 'root'
-  action :create
+# CRON Permitted Users
+template '/etc/cron.allow' do
+  source  'etc_cron.allow.erb'
+  owner   'root'
+  group   'root'
+  mode    0o600
 end
 
 file '/etc/at.deny' do

--- a/templates/default/etc_cron.allow.erb
+++ b/templates/default/etc_cron.allow.erb
@@ -1,0 +1,7 @@
+# DO NOT EDIT - CREATED BY CHEF COOKBOOK - stig:file_permissions
+# CHANGES WILL BE OVERWRITTEN BY CHEF
+# /etc/cron.allow
+# Users Allowed to use CRON
+#
+root
+


### PR DESCRIPTION
Added /var/spool/cron (V-4360) for folder permission management and an ERB file template for /etc/cron.allow versus empty file to recipes/file_permissions.rb. The STIG scanner typically wants you to explicitly state root (or any other users) have CRON access. 