### PR TITLE
Prevent SMTP Relaying in RHEL per DISA STIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 -- [isuftin@usgs.gov] - STIG 6.1.6 - File permissions for /etc/passwd-
 -- [cpoma@mitre.org] - Added default["stig"]["mount_disable"]["disable_usb_storage"] to disable USB Storage. RHEL-06-000503 - CCI-001250
+-- [cpoma@mitre.org] - Added default['stig']['postfix']['smtpd_client_restrictions_rhel'] for use in 
+templates/default/etc_man.cf_rhel.erb to disable mail relaying. RHEL-07-040480 - CCI-000366
 ### Updated
 -- [isuftin@usgs.gov] - STIG 6.2.7 - Update script to check for users having a home dir
 -- [isuftin@usgs.gov] - Narrowed down sshd MACs config to what works for EL6 and EL7

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1348,6 +1348,12 @@ default['stig']['postfix']['relayhost'] = ''
 # In the left-hand side, specify an @domain.tld wild-card, or specify
 # a user@domain.tld address.
 #
+# Redhat restriction that the Postfix SMTP server applies in the context of a
+# client connection request. DISA STIG requires the system to be configured to
+# prevent unrestricted mail relaying. RHEL-07-040480 - CCI-000366
+# DISA REDHAT STIG Setting: "permit_mynetworks, reject"
+default['stig']['postfix']['smtpd_client_restrictions_rhel'] = 'permit_mynetworks, reject'
+#
 # relay_recipient_maps = hash:/etc/postfix/relay_recipients
 default['stig']['postfix']['relay_recipient_maps'] = ''
 # The in_flow_delay configuration parameter implements mail input

--- a/templates/default/etc_main.cf_rhel.erb
+++ b/templates/default/etc_main.cf_rhel.erb
@@ -329,6 +329,14 @@ mynetworks = <%= node['stig']['postfix']['mynetworks'] %>
 relay_domains = <%= node['stig']['postfix']['relay_domains'] %>
 <% end %>
 
+<% if node['stig']['postfix']['smtpd_client_restrictions_rhel'] -%>
+# Redhat restriction that the Postfix SMTP server applies in the context of a 
+# client connection request. DISA STIG requires the system to be configured to 
+# prevent unrestricted mail relaying. RHEL-07-040480 - CCI-000366
+# DISA REDHAT STIG Setting: "permit_mynetworks, reject"
+smtpd_client_restrictions = <%= node['stig']['postfix']['smtpd_client_restrictions_rhel'] %>
+<% end -%>
+
 # INTERNET OR INTRANET
 
 # The relayhost parameter specifies the default host to send mail to


### PR DESCRIPTION
Added default['stig']['postfix']['smtpd_client_restrictions_rhel'] for use in templates/default/etc_man.cf_rhel.erb to disable mail relaying. RHEL-07-040480 - CCI-000366