### PR TITLE
V-72257 - The SSH private host key files must have mode 0600 or less permissive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ sysctl cookbook version >= 1.0.0
 -- [isuftin@usgs.gov] - Add guard to sysctl call in order to work around bug https://github.com/chef/chef/issues/7189
 -- [isuftin@usgs.gov] - Switched Changelog format
 -- [isuftin@usgs.gov] - Fixed styling for Rubocop 0.55.0
+-- [kdshah@mitre.org] - Added SSH private host key file permission to recipe/sshd_config.rb
 ### Fixed
 -- [cpoma@mitre.org] - Bugfix in stig/recipes/mail_transfer_agent.rb to use platform_family versus platform
 -- [cpoma@mitre.org] - Bugfix in stig/attributes/default.rb - Errors out and sshd dies (bricking machine) on RH 7

--- a/recipes/sshd_config.rb
+++ b/recipes/sshd_config.rb
@@ -113,6 +113,18 @@ template '/etc/ssh/sshd_config' do
   notifies :restart, 'service[sshd]', :delayed
 end
 
+# control "V-72257" do
+# title "The SSH private host key files must have mode 0600 or less permissive."
+# desc  "If an unauthorized user obtains the private SSH host key file, the host
+# could be impersonated."
+Dir.glob('/etc/ssh/*ssh_host*key') do |keyfile|
+  directory keyfile do
+    owner 'root'
+    group 'root'
+    mode 0o600
+  end
+end
+
 service 'sshd' do
   action :nothing
 end


### PR DESCRIPTION
Per Redhat STIG - http://rhel7stig.readthedocs.io/en/latest/medium.html#v-72257-the-ssh-private-host-key-files-must-have-mode-0600-or-less-permissive-rhel-07-040420
