### PR TITLE
AIDE updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 ### Added
+-- [isuftin@usgs.gov] - No longer passing output database location to aide init
+command. Let aide get that from the conf file
+-- [isuftin@usgs.gov] - Use proper output database location during aide init
+-- [isuftin@usgs.gov] - Make sure to copy new aide database to old database location
+post-init
 -- [isuftin@usgs.gov] - Sticking to major version of CentOS in Test Kitchen
 -- [isuftin@usgs.gov] - STIG 6.1.6 - File permissions for /etc/passwd-
 -- [cpoma@mitre.org] - Added default["stig"]["mount_disable"]["disable_usb_storage"] to disable USB Storage. RHEL-06-000503 - CCI-001250

--- a/spec/aide_spec.rb
+++ b/spec/aide_spec.rb
@@ -27,9 +27,16 @@ describe 'stig::aide CentOS 7.x' do
     expect(aide_config).to notify('execute[init_aide]').to(:run).delayed
   end
 
+  it 'should not run copy new to old database for RHEL' do
+    expect(chef_run).to_not create_remote_file('Copy new database to old')
+    resource = chef_run.remote_file('Copy new database to old')
+    expect(resource).to do_nothing
+  end
+
   it 'should not execute init_aide by default for RHEL' do
     exec_init_aide = chef_run.execute('init_aide')
     expect(exec_init_aide).to do_nothing
+    expect(exec_init_aide).to notify('remote_file[Copy new database to old]').to(:create).immediately
   end
 
   # 1.3.2

--- a/test/integration/centos6/inspec/controls/aide_spec.rb
+++ b/test/integration/centos6/inspec/controls/aide_spec.rb
@@ -7,6 +7,11 @@ describe file('/var/lib/aide/aide.db.gz') do
   it { should be_owned_by 'root' }
 end
 
+describe file('/var/lib/aide/aide.db.new.gz') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+end
+
 describe file('/var/lib/aide/aide.db') do
   it { should_not be_file }
 end
@@ -33,4 +38,3 @@ if %w(rhel fedora centos redhat).include?(os[:family])
     its('weekdays') { should cmp '*' }
   end
 end
-

--- a/test/integration/centos7/inspec/controls/aide_spec.rb
+++ b/test/integration/centos7/inspec/controls/aide_spec.rb
@@ -26,6 +26,11 @@ if %w(rhel fedora centos redhat).include?(os[:family])
     it { should be_owned_by 'root' }
   end
 
+  describe file('/var/lib/aide/aide.db.new.gz') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+  end
+
   describe crontab('root').commands('/usr/sbin/aide --check')  do
     its('minutes') { should cmp 0 }
     its('hours') { should cmp 5 }


### PR DESCRIPTION
-- [isuftin@usgs.gov] - No longer passing output database location to aide init
command. Let aide get that from the conf file.
-- [isuftin@usgs.gov] - Use proper output database location during aide init
-- [isuftin@usgs.gov] - Make sure to copy new aide database to old database location
post-init