### PR TITLE
Add compatibility for Chef 14.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,7 +4,6 @@ metadata
 
 cookbook 'auditd', '~> 2.2.0'
 cookbook 'logrotate', '~> 2.2.0'
-cookbook 'sysctl'
 
 # The following is optional and only used if testing on the DOI network
 cookbook 'doi_ssl_filtering', github: 'USGS-CIDA/chef-cookbook-doi-ssl-filtering', tag: 'v1.0.6'

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,3 @@ supports         'ubuntu'
 chef_version     '>= 12.0.0'
 
 depends          'logrotate'
-depends          'sysctl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,6 @@ supports         'centos', '>= 6.6'
 supports         'centos', '>= 7.1'
 supports         'ubuntu'
 
-chef_version     '>= 12.0.0'
+chef_version     '>= 14.0.0'
 
 depends          'logrotate'

--- a/recipes/proc_hard.rb
+++ b/recipes/proc_hard.rb
@@ -23,7 +23,7 @@ package 'whoopsie' do
 end
 
 node['sysctl']['params'].each do |param, value|
-  sysctl_param param do
+  sysctl param do
     key param
     value value
     only_if "sysctl -n #{param}"


### PR DESCRIPTION
With Chef 12 well past it EOL and Chef 13 approaching that status in a few days this adds support for Chef 14.  Most notably this migrates away from the sysctl cookbook, which is no longer supported in Chef 14, and instead utilizes Chef 14's sysctl resource.