### PR TITLE
Add path strings (allow wildcard) to ignore during audits recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 
+## [1.0.2] - 2019-12-17
+
+### Added
+-- [isuftin@usgs.gov] - Add path strings (allow wildcard) to ignore during audits
+  recipe. Paths included will not be checked as orphans or world writeable permissions
+  
 ## [1.0.1] - 2019-12-10
 
 ### Changed

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@ default['stig']['limits'] = [
 # Audit configuration
 default['stig']['audits']['bash_timeout'] = 7200
 default['stig']['audits']['guard_timeout'] = 7200
+# Add path strings (allow wildcard) to ignore during audits recipe. Paths included
+# here will not be checked as orphans or world writeable permissions
+default['stig']['audits']['ignore_paths'] = []
 
 # Aide configuration
 # See https://linux.die.net/man/5/aide.conf

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'isuftin@usgs.gov'
 license          'CPL-1.0'
 description      'Installs/Configures CIS STIG benchmarks'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.2'
 source_url       'https://github.com/USGS-CIDA/stig'
 issues_url       'https://github.com/USGS-CIDA/stig/issues'
 

--- a/recipes/audits.rb
+++ b/recipes/audits.rb
@@ -20,7 +20,7 @@
 # - Verify No UID 0 Accounts Exist Other Than root
 
 ignore_paths = ''
-node['stig']['audits']['ignore_paths'].each {|p| ignore_paths += "-not -path \"#{p}\" "}
+node['stig']['audits']['ignore_paths'].each { |p| ignore_paths += "-not -path \"#{p}\" " }
 
 bash 'remove_world_writable_flag_from_files' do
   user 'root'

--- a/spec/audits_spec.rb
+++ b/spec/audits_spec.rb
@@ -20,11 +20,11 @@ describe 'stig::audits CentOS 7.x' do
   end
 
   before do
-    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -type f -perm -0002)\"").and_return(true)
+    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -type f -perm -0002)\"").and_return(true)
   end
 
   before do
-    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -nogroup)\"").and_return(true)
+    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -ignore_readdir_race -nouser -nogroup)\"").and_return(true)
   end
 
   before do
@@ -62,14 +62,14 @@ describe 'stig::audits CentOS 7.x' do
   it 'checks for world writable files' do
     expect(chef_run).to run_bash('remove_world_writable_flag_from_files').with(
       user: 'root',
-      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -type f -perm -0002 | while read fn ;do chmod o-w \"$fn\";done"
+      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -type f -perm -0002 | while read fn ;do chmod o-w \"$fn\";done"
     )
   end
 
   it 'checks for unowned files and directories' do
     expect(chef_run).to run_bash('find user and group orphaned files and directories').with(
       user: 'root',
-      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -nogroup | while read fn;do chown root:root \"$fn\";done"
+      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -ignore_readdir_race -nouser -nogroup | while read fn;do chown root:root \"$fn\";done"
     )
   end
 
@@ -101,11 +101,11 @@ describe 'stig::audits CentOS 6.x' do
   end
 
   before do
-    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -type f -perm -0002)\"").and_return(true)
+    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -type f -perm -0002)\"").and_return(true)
   end
 
   before do
-    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -nogroup)\"").and_return(true)
+    stub_command("test -n \"$(df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -ignore_readdir_race -nouser -nogroup)\"").and_return(true)
   end
 
   before do
@@ -143,14 +143,14 @@ describe 'stig::audits CentOS 6.x' do
   it 'checks for world writable files' do
     expect(chef_run).to run_bash('remove_world_writable_flag_from_files').with(
       user: 'root',
-      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -type f -perm -0002 | while read fn ;do chmod o-w \"$fn\";done"
+      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -type f -perm -0002 | while read fn ;do chmod o-w \"$fn\";done"
     )
   end
 
   it 'checks for unowned files and directories' do
     expect(chef_run).to run_bash('find user and group orphaned files and directories').with(
       user: 'root',
-      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}' -xdev -ignore_readdir_race -nouser -nogroup | while read fn;do chown root:root \"$fn\";done"
+      code: "df --local -P | awk {'if (NR!=1) print $6'} | uniq | xargs -I '{}' find '{}'  -xdev -ignore_readdir_race -nouser -nogroup | while read fn;do chown root:root \"$fn\";done"
     )
   end
 


### PR DESCRIPTION
Paths included will not be checked as orphans or world writeable permissions