### PR TITLE
AIDE Updates

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,6 @@ source 'https://supermarket.getchef.com'
 
 metadata
 
-cookbook 'auditd', '~> 2.3.4'
-cookbook 'logrotate', '~> 2.2.2'
-cookbook 'rsyslog', '~> 6.0.7'
+cookbook 'auditd', '~> 2.4.0'
+cookbook 'logrotate', '~> 2.2.3'
+cookbook 'rsyslog', '~> 7.0.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 
+## [1.0.3] - 2020-06-24
+
+### Added
+-- [isuftin@usgs.gov] - Add ability to set a crontab to update the AIDE database
+  every day at mignight UTC. By default this is disabled.
+
+### Changed
+-- [isuftin@usgs.gov] - Update dependencies for logrotate, rsyslog and auditd
+community cookbooks
+
 ## [1.0.2] - 2019-12-17
 
 ### Added
 -- [isuftin@usgs.gov] - Add path strings (allow wildcard) to ignore during audits
   recipe. Paths included will not be checked as orphans or world writeable permissions
-  
+
 ## [1.0.1] - 2019-12-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Attributes
 
 - `node['stig']['aide']['report_url']` = (Array of Strings) Specifies where the output is sent. Default: [ 'file:@@{LOGDIR}/aide.log', 'stdout' ]
 
-- `node['stig']['aide']['set_update_cron']` = (Boolean) If true, a crontab will be created to update the AIDE database at midnight UTC every day. Default: false
+- `node['stig']['aide']['set_update_cron']` = (Boolean) If true, also update the database after the daily aide check so the next check will use
+  a fresh database
 
 - `node['stig']['aide']['rules']` = (Hash) Defines additional rules to be used. The hash entry is in the form of Rule Name => definition. Default: See https://github.com/USGS-CIDA/stig/blob/master/attributes/default.rb]
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Requirements
 - CentOS >= 7.1
 
 ### Cookbooks
-- auditd ~> 2.3.4
-- logrotate ~> 2.2.0
-- rsyslog ~> 6.0.7
+- auditd ~> 2.4.0
+- logrotate ~> 2.2.3
+- rsyslog ~> 7.0.1
 
 [Changelog](CHANGELOG.md)
 ---------
@@ -44,6 +44,8 @@ Attributes
 - `node['stig']['aide']['verbose']` = (Integer 0-255) Specifies the level of the messages that are written out. Default: 5
 
 - `node['stig']['aide']['report_url']` = (Array of Strings) Specifies where the output is sent. Default: [ 'file:@@{LOGDIR}/aide.log', 'stdout' ]
+
+- `node['stig']['aide']['set_update_cron']` = (Boolean) If true, a crontab will be created to update the AIDE database at midnight UTC every day. Default: false
 
 - `node['stig']['aide']['rules']` = (Hash) Defines additional rules to be used. The hash entry is in the form of Rule Name => definition. Default: See https://github.com/USGS-CIDA/stig/blob/master/attributes/default.rb]
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['stig']['aide']['database_out'] = 'file:@@{DBDIR}/aide.db.new.gz'
 default['stig']['aide']['gzip_dbout'] = true
 default['stig']['aide']['verbose'] = 5
 default['stig']['aide']['timeout'] = 7200
+default['stig']['aide']['set_update_cron'] = false
 default['stig']['aide']['report_url'] = [
   'file:@@{LOGDIR}/aide.log',
   'stdout'

--- a/recipes/aide.rb
+++ b/recipes/aide.rb
@@ -121,5 +121,5 @@ cron 'aide_update_cron' do
   action :create
   not_if 'crontab -u root -l | grep "aide_update_cron"'
   only_if { %w[rhel fedora centos redhat].include? platform }
-  only_if { node['stig']['aide']['set_update_cron'] == true}
+  only_if { node['stig']['aide']['set_update_cron'] == true }
 end

--- a/recipes/aide.rb
+++ b/recipes/aide.rb
@@ -108,6 +108,18 @@ cron 'aide_cron' do
   day '*'
   month '*'
   action :create
-  not_if 'crontab -u root -l | grep aide'
+  not_if 'crontab -u root -l | grep "aide_cron"'
   only_if { %w[rhel fedora centos redhat].include? platform }
+end
+
+cron 'aide_update_cron' do
+  command "/usr/sbin/aide --update || true && rm #{aide_db_path} -f; cp #{aide_db_out_path} #{aide_db_path} -f"
+  minute '0'
+  hour '0'
+  day '*'
+  month '*'
+  action :create
+  not_if 'crontab -u root -l | grep "aide_update_cron"'
+  only_if { %w[rhel fedora centos redhat].include? platform }
+  only_if { node['stig']['aide']['set_update_cron'] == true}
 end

--- a/recipes/aide.rb
+++ b/recipes/aide.rb
@@ -101,25 +101,16 @@ remote_file 'Copy new database to old' do
   action :nothing
 end
 
+aide_cron_cmd = '/usr/sbin/aide --check || true'
+
+aide_cron_cmd = "#{aide_cron_cmd} && /usr/sbin/aide --update || true && rm #{aide_db_path} -f; cp #{aide_db_out_path} #{aide_db_path} -f" if node['stig']['aide']['set_update_cron'] == true
+
 cron 'aide_cron' do
-  command '/usr/sbin/aide --check'
+  command aide_cron_cmd
   minute '0'
   hour '5'
   day '*'
   month '*'
   action :create
-  not_if 'crontab -u root -l | grep "aide_cron"'
   only_if { %w[rhel fedora centos redhat].include? platform }
-end
-
-cron 'aide_update_cron' do
-  command "/usr/sbin/aide --update || true && rm #{aide_db_path} -f; cp #{aide_db_out_path} #{aide_db_path} -f"
-  minute '0'
-  hour '0'
-  day '*'
-  month '*'
-  action :create
-  not_if 'crontab -u root -l | grep "aide_update_cron"'
-  only_if { %w[rhel fedora centos redhat].include? platform }
-  only_if { node['stig']['aide']['set_update_cron'] == true }
 end

--- a/spec/aide_spec.rb
+++ b/spec/aide_spec.rb
@@ -4,7 +4,7 @@ describe 'stig::aide CentOS 7.x' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.7.1908').converge('stig::aide') }
 
   before do
-    stub_command('crontab -u root -l | grep \"aide_cron\"').and_return(false)
+    stub_command('crontab -u root -l | grep "aide_cron"').and_return(false)
   end
 
   # 1.3.1
@@ -61,7 +61,7 @@ describe 'stig::aide CentOS 6.x' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '6.9').converge('stig::aide') }
 
   before do
-    stub_command('crontab -u root -l | grep \"aide_cron\"').and_return(false)
+    stub_command('crontab -u root -l | grep "aide_cron"').and_return(false)
   end
 
   # 1.3.1
@@ -93,19 +93,9 @@ describe 'stig::aide CentOS 6.x' do
   # 1.3.2
   it 'checks for aide on a schedule' do
     expect(chef_run).to create_cron('aide_cron').with(
-      command: '/usr/sbin/aide --check',
+      command: '/usr/sbin/aide --check || true',
       minute: '0',
       hour: '5',
-      day: '*',
-      month: '*'
-    )
-  end
-
-  it 'checks for aide on a schedule' do
-    expect(chef_run).to create_cron('aide_cron').with(
-      command: '/usr/sbin/aide --update || true && rm /var/lib/aide/aide.db.gz -f; cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz -f',
-      minute: '0',
-      hour: '0',
       day: '*',
       month: '*'
     )

--- a/spec/aide_spec.rb
+++ b/spec/aide_spec.rb
@@ -101,6 +101,16 @@ describe 'stig::aide CentOS 6.x' do
     )
   end
 
+  it 'checks for aide on a schedule' do
+    expect(chef_run).to create_cron('aide_cron').with(
+      command: '/usr/sbin/aide --update || true && rm /var/lib/aide/aide.db.gz -f; cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz -f',
+      minute: '0',
+      hour: '0',
+      day: '*',
+      month: '*'
+    )
+  end
+
   it 'Does not create remote file on CentOS' do
     expect(chef_run).to_not create_remote_file('/var/lib/aide/aide.db').with(
       user: 'root',

--- a/spec/aide_spec.rb
+++ b/spec/aide_spec.rb
@@ -4,7 +4,7 @@ describe 'stig::aide CentOS 7.x' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.7.1908').converge('stig::aide') }
 
   before do
-    stub_command('crontab -u root -l | grep aide').and_return(false)
+    stub_command('crontab -u root -l | grep \"aide_cron\"').and_return(false)
   end
 
   # 1.3.1
@@ -61,7 +61,7 @@ describe 'stig::aide CentOS 6.x' do
   let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '6.9').converge('stig::aide') }
 
   before do
-    stub_command('crontab -u root -l | grep aide').and_return(false)
+    stub_command('crontab -u root -l | grep \"aide_cron\"').and_return(false)
   end
 
   # 1.3.1

--- a/spec/aide_spec.rb
+++ b/spec/aide_spec.rb
@@ -42,7 +42,7 @@ describe 'stig::aide CentOS 7.x' do
   # 1.3.2
   it 'checks for aide on a schedule' do
     expect(chef_run).to create_cron('aide_cron').with(
-      command: '/usr/sbin/aide --check',
+      command: '/usr/sbin/aide --check || true',
       minute: '0',
       hour: '5',
       day: '*',

--- a/test/integration/centos6/inspec/controls/aide_spec.rb
+++ b/test/integration/centos6/inspec/controls/aide_spec.rb
@@ -41,5 +41,13 @@ control 'aide' do
       its('months') { should cmp '*' }
       its('weekdays') { should cmp '*' }
     end
+
+    describe crontab('root').commands('/usr/sbin/aide --update || true && rm /var/lib/aide/aide.db.gz -f; cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz -f')  do
+      its('minutes') { should cmp 0 }
+      its('hours') { should cmp 0 }
+      its('days') { should cmp '*' }
+      its('months') { should cmp '*' }
+      its('weekdays') { should cmp '*' }
+    end
   end
 end

--- a/test/integration/centos6/inspec/controls/aide_spec.rb
+++ b/test/integration/centos6/inspec/controls/aide_spec.rb
@@ -34,17 +34,9 @@ control 'aide' do
       its(:content) { should match('^LSPP\s*=') }
     end
 
-    describe crontab('root').commands('/usr/sbin/aide --check')  do
+    describe crontab('root').commands('/usr/sbin/aide --check || true')  do
       its('minutes') { should cmp 0 }
       its('hours') { should cmp 5 }
-      its('days') { should cmp '*' }
-      its('months') { should cmp '*' }
-      its('weekdays') { should cmp '*' }
-    end
-
-    describe crontab('root').commands('/usr/sbin/aide --update || true && rm /var/lib/aide/aide.db.gz -f; cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz -f')  do
-      its('minutes') { should cmp 0 }
-      its('hours') { should cmp 0 }
       its('days') { should cmp '*' }
       its('months') { should cmp '*' }
       its('weekdays') { should cmp '*' }

--- a/test/integration/centos7/inspec/controls/aide_spec.rb
+++ b/test/integration/centos7/inspec/controls/aide_spec.rb
@@ -36,16 +36,9 @@ control 'aide' do
       it { should be_owned_by 'root' }
     end
 
-    describe crontab('root').commands('/usr/sbin/aide --check')  do
+    describe crontab('root').commands('/usr/sbin/aide --check || true')  do
       its('minutes') { should cmp 0 }
       its('hours') { should cmp 5 }
-      its('days') { should cmp '*' }
-      its('months') { should cmp '*' }
-      its('weekdays') { should cmp '*' }
-    end
-    describe crontab('root').commands('/usr/sbin/aide --update || true && rm /var/lib/aide/aide.db.gz -f; cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz -f')  do
-      its('minutes') { should cmp 0 }
-      its('hours') { should cmp 0 }
       its('days') { should cmp '*' }
       its('months') { should cmp '*' }
       its('weekdays') { should cmp '*' }

--- a/test/integration/centos7/inspec/controls/aide_spec.rb
+++ b/test/integration/centos7/inspec/controls/aide_spec.rb
@@ -43,6 +43,13 @@ control 'aide' do
       its('months') { should cmp '*' }
       its('weekdays') { should cmp '*' }
     end
+    describe crontab('root').commands('/usr/sbin/aide --update || true && rm /var/lib/aide/aide.db.gz -f; cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz -f')  do
+      its('minutes') { should cmp 0 }
+      its('hours') { should cmp 0 }
+      its('days') { should cmp '*' }
+      its('months') { should cmp '*' }
+      its('weekdays') { should cmp '*' }
+    end
   end
 
   # UBUNTU: 8.3.2


### PR DESCRIPTION
-- [isuftin@usgs.gov] - Add ability to set a crontab to update the AIDE database

  every day at mignight UTC. By default this is disabled.

-- [isuftin@usgs.gov] - Update dependencies for logrotate, rsyslog and auditd
community cookbooks